### PR TITLE
ActionPick changed for video to ActionGetContent

### DIFF
--- a/MediaGallery/MediaFile/MediaFile.android.cs
+++ b/MediaGallery/MediaFile/MediaFile.android.cs
@@ -1,17 +1,19 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Android.Webkit;
+using Uri = Android.Net.Uri;
 
 namespace Xamarin.MediaGallery
 {
     public partial class MediaFile
     {
-        internal static MediaFile Create(string fileName, string extension, Func<Task<Stream>> openReadAsync)
-            => new MediaFile(
-                fileName,
-                extension,
-                MimeTypeMap.Singleton.GetMimeTypeFromExtension(extension.TrimStart('.')),
-                openReadAsync);
+        internal MediaFile(string fileName, Uri uri)
+        {
+            FileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+            Extension = Path.GetExtension(fileName)?.TrimStart('.');
+            ContentType = MimeTypeMap.Singleton.GetMimeTypeFromExtension(Extension);
+            openReadAsync =
+                () => Task.FromResult(Platform.AppActivity.ContentResolver.OpenInputStream(uri));
+        }
     }
 }

--- a/MediaGallery/MediaFile/MediaFile.shared.cs
+++ b/MediaGallery/MediaFile/MediaFile.shared.cs
@@ -14,11 +14,6 @@ namespace Xamarin.MediaGallery
             Extension = extension.TrimStart('.');
             ContentType = contentType.ToLower();
             this.openReadAsync = openReadAsync;
-            Type = ContentType.StartsWith("image")
-                ? MediaFileType.Image
-                : ContentType.StartsWith("video")
-                    ? MediaFileType.Video
-                    : (MediaFileType?)null;
         }
 
         public string FileName => $"{FileNameWithoutExtension}.{Extension}";
@@ -29,7 +24,11 @@ namespace Xamarin.MediaGallery
 
         public string ContentType { get; }
 
-        public MediaFileType? Type { get; }
+        public MediaFileType? Type => ContentType.StartsWith("image")
+                ? MediaFileType.Image
+                : ContentType.StartsWith("video")
+                    ? MediaFileType.Video
+                    : (MediaFileType?)null;
 
         public Task<Stream> OpenReadAsync()
             => openReadAsync?.Invoke();

--- a/MediaGallery/MediaGallery/PickMedia.android.cs
+++ b/MediaGallery/MediaGallery/PickMedia.android.cs
@@ -23,7 +23,8 @@ namespace Xamarin.MediaGallery
 
             Intent intent;
 
-            if(isImage && types.Length == 1)
+            // https://github.com/dimonovdd/Xamarin.MediaGallery/pull/5
+            if (isImage && types.Length == 1)
             {
                 intent = new Intent(Intent.ActionPick, MediaStore.Images.Media.ExternalContentUri);
                 intent.SetType(imageType);

--- a/MediaGallery/MediaGallery/PickMedia.android.cs
+++ b/MediaGallery/MediaGallery/PickMedia.android.cs
@@ -6,7 +6,7 @@ using Android.App;
 using Android.Content;
 using Uri = Android.Net.Uri;
 using FileColumns = Android.Provider.MediaStore.Files.FileColumns;
-using Path = System.IO.Path;
+using Android.Provider;
 
 namespace Xamarin.MediaGallery
 {
@@ -14,33 +14,34 @@ namespace Xamarin.MediaGallery
     {
         const string imageType = "image/*";
         const string videoType = "video/*";
-        const string allType = "*/*";
         static TaskCompletionSource<Intent> tcs;
 
         static async Task<IEnumerable<IMediaFile>> PlatformPickAsync(int selectionLimit, params MediaFileType[] types)
         {
-            var isVideo = types.Contains(MediaFileType.Video);
             var isImage = types.Contains(MediaFileType.Image);
             tcs = new TaskCompletionSource<Intent>();
 
             Intent intent;
 
-            if(isImage && !isVideo)
+            if(isImage && types.Length == 1)
             {
-                intent = new Intent(Intent.ActionPick);
+                intent = new Intent(Intent.ActionPick, MediaStore.Images.Media.ExternalContentUri);
                 intent.SetType(imageType);
+                intent.PutExtra(Intent.ExtraMimeTypes, new string[] { imageType });
             }
             else
             {
                 intent = new Intent(Intent.ActionGetContent);
 
-                intent.SetType(isImage ? allType : videoType);
-                intent.PutExtra(Intent.ExtraMimeTypes, isImage
+                intent.SetType(isImage ? $"{imageType}, {videoType}" : videoType);
+                intent.PutExtra(
+                    Intent.ExtraMimeTypes,
+                    isImage
                     ? new string[] { imageType, videoType }
                     : new string[] { videoType });
             }
 
-            intent.PutExtra(Intent.ExtraLocalOnly, true);
+            intent.PutExtra(Intent.ExtraLocalOnly, false);
             intent.PutExtra(Intent.ExtraAllowMultiple, selectionLimit > 1);
 
             Platform.AppActivity.StartActivityForResult(intent, Platform.requestCode);
@@ -61,38 +62,37 @@ namespace Xamarin.MediaGallery
 
         static IEnumerable<IMediaFile> GetFilesFromIntent(Intent intent)
         {
-            var clipData = intent?.ClipData;
+            var clipCount = intent?.ClipData?.ItemCount ?? 0;
             var data = intent?.Data;
 
-            if (clipData != null)
-                for (var i = 0; i < clipData.ItemCount; i++)
+            if (data != null && !(clipCount > 1))
+            {
+                var res = GetFileResult(data);
+                if (res != null)
+                    yield return res;
+            }
+            else if (clipCount > 0)
+                for (var i = 0; i < clipCount; i++)
                 {
-                   var item = clipData.GetItemAt(i);
-                   yield return GetFileResult(item.Uri);
+                    var item = intent.ClipData.GetItemAt(i);
+                    var res = GetFileResult(item.Uri);
+                    if (res != null)
+                        yield return res;
                 }
-            else if(data != null)
-                yield return GetFileResult(data);
         }
 
 
         static IMediaFile GetFileResult(Uri uri)
         {
             var name = QueryContentResolverColumn(uri, FileColumns.DisplayName);
-            var fileName = Path.GetFileNameWithoutExtension(name);
-            var extension = Path.GetExtension(name);
-
-            return MediaFile.Create(
-                fileName,
-                extension,
-                () => Task.FromResult(
-                    Platform.AppActivity.ContentResolver.OpenInputStream(uri)));
+            return string.IsNullOrWhiteSpace(name)
+                ? null
+                : new MediaFile(name, uri);
         }
 
 
         static string QueryContentResolverColumn(Uri contentUri, string columnName)
         {
-            string data = null;
-
             try
             {
                 using var cursor = Platform.AppActivity.ContentResolver
@@ -102,14 +102,14 @@ namespace Xamarin.MediaGallery
                 {
                     var columnIndex = cursor.GetColumnIndex(columnName);
                     if (columnIndex != -1)
-                        data = cursor.GetString(columnIndex);
+                        return cursor.GetString(columnIndex);
                 }
+                return null;
             }
             catch
             {
+                return null;
             }
-
-            return data;
         }
     }
 }

--- a/Sample/Sample/ViewModels/PickVM.cs
+++ b/Sample/Sample/ViewModels/PickVM.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.MediaGallery;
 
@@ -34,7 +36,8 @@ namespace Sample.ViewModels
         {
             try
             {
-                SelectedItems = (await MediaGallery.PickAsync(SelectionLimit, types))?.Files;
+                var result = await MediaGallery.PickAsync(SelectionLimit, types);
+                SelectedItems = result?.Files?.ToArray();
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
### Description
ActionPick works well with images. But the filtering doesn't work correctly for video files.
Despite filtering by mimeType "video/*", in some applications, the user still has the option to select images. 

So ActionPick will only use for images

### PR Checklist ###

- [x] All projects build
- [x] Has samples
- [x] Rebased onto current `main`