### PR TITLE
Changed RootNamespace

### DIFF
--- a/MediaGallery/ExeptionHelper/ExeptionHelper.shared.cs
+++ b/MediaGallery/ExeptionHelper/ExeptionHelper.shared.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     static class ExeptionHelper
     {

--- a/MediaGallery/MediaFile/IMediaFile.shared.cs
+++ b/MediaGallery/MediaFile/IMediaFile.shared.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     /// <summary>Describes and allows to open a media file</summary>
     public interface IMediaFile : IDisposable

--- a/MediaGallery/MediaFile/MediaFile.android.cs
+++ b/MediaGallery/MediaFile/MediaFile.android.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Android.Webkit;
 using Uri = Android.Net.Uri;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     partial class MediaFile
     {

--- a/MediaGallery/MediaFile/MediaFile.ios.cs
+++ b/MediaGallery/MediaFile/MediaFile.ios.cs
@@ -5,7 +5,7 @@ using Foundation;
 using MobileCoreServices;
 using UIKit;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     partial class MediaFile
     {

--- a/MediaGallery/MediaFile/MediaFile.netstandard.cs
+++ b/MediaGallery/MediaFile/MediaFile.netstandard.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     partial class MediaFile : IMediaFile
     {

--- a/MediaGallery/MediaFile/MediaFile.shared.cs
+++ b/MediaGallery/MediaFile/MediaFile.shared.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     partial class MediaFile : IMediaFile
     {

--- a/MediaGallery/MediaGallery.csproj
+++ b/MediaGallery/MediaGallery.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;Xamarin.iOS10;MonoAndroid10.0;MonoAndroid11.0;</TargetFrameworks>
-    <AssemblyName>Xamarin.MediaGallery</AssemblyName>
-    <RootNamespace>Xamarin.MediaGallery</RootNamespace>
+    <AssemblyName>NativeMedia</AssemblyName>
+    <RootNamespace>NativeMedia</RootNamespace>
     <PackageId>Xamarin.MediaGallery</PackageId>
     <PackageIcon>icon.png</PackageIcon>
     <Summary>This plugin is designed for picking and saving photos and video files from the native gallery of Android and iOS devices</Summary>
@@ -13,7 +13,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0.0</Version>
-    <PackageVersion>1.0.0.0-alpha003</PackageVersion>
+    <PackageVersion>1.0.0.0-alpha005</PackageVersion>
     <Authors>dimonovdd</Authors>
     <Owners>dimonovdd</Owners>
     <PackageProjectUrl>https://github.com/dimonovdd/Xamarin.MediaGallery</PackageProjectUrl>

--- a/MediaGallery/MediaGallery/MediaFileType.shared.cs
+++ b/MediaGallery/MediaGallery/MediaFileType.shared.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     /// <summary>Enumeration media files</summary>
     public enum MediaFileType

--- a/MediaGallery/MediaGallery/MediaGallery.netstandard.cs
+++ b/MediaGallery/MediaGallery/MediaGallery.netstandard.cs
@@ -2,20 +2,20 @@
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public static partial class MediaGallery
     {
         static Task<IEnumerable<IMediaFile>> PlatformPickAsync(int selectionLimit, params MediaFileType[] types)
-            => throw ExeptionHelper.NotSupportedOrImplementedException;
+            => Task.FromResult<IEnumerable<IMediaFile>>(null);
 
         static Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName)
-             => throw ExeptionHelper.NotSupportedOrImplementedException;
+             => Task.CompletedTask;
 
         static Task PlatformSaveAsync(MediaFileType type, string filePath)
-            => throw ExeptionHelper.NotSupportedOrImplementedException;
+            => Task.CompletedTask;
 
         static Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName)
-            => throw ExeptionHelper.NotSupportedOrImplementedException;
+            => Task.CompletedTask;
     }
 }

--- a/MediaGallery/MediaGallery/MediaGallery.shared.cs
+++ b/MediaGallery/MediaGallery/MediaGallery.shared.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     /// <summary>Performs operations with media files.</summary>
     public static partial class MediaGallery

--- a/MediaGallery/MediaGallery/PickMedia.android.cs
+++ b/MediaGallery/MediaGallery/PickMedia.android.cs
@@ -13,7 +13,7 @@ using MediaColumns = Android.Provider.MediaStore.MediaColumns;
 #endif
 
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public static partial class MediaGallery
     {

--- a/MediaGallery/MediaGallery/PickMedia.ios.cs
+++ b/MediaGallery/MediaGallery/PickMedia.ios.cs
@@ -10,7 +10,7 @@ using PhotosUI;
 using UIKit;
 using Xamarin.Essentials;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public static partial class MediaGallery
     {

--- a/MediaGallery/MediaGallery/SaveMedia.android.cs
+++ b/MediaGallery/MediaGallery/SaveMedia.android.cs
@@ -16,7 +16,7 @@ using MediaColumns = Android.Provider.MediaStore.IMediaColumns;
 using MediaColumns = Android.Provider.MediaStore.MediaColumns;
 #endif
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public static partial class MediaGallery
     {

--- a/MediaGallery/MediaGallery/SaveMedia.ios.cs
+++ b/MediaGallery/MediaGallery/SaveMedia.ios.cs
@@ -5,7 +5,7 @@ using Foundation;
 using Photos;
 using Xamarin.Essentials;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public static partial class MediaGallery
     {

--- a/MediaGallery/MediaPickResult/MediaPickResult.shared.cs
+++ b/MediaGallery/MediaPickResult/MediaPickResult.shared.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     /// <summary>Describes the result of the <see cref="MediaGallery.PickAsync"/> method</summary>
     public sealed class MediaPickResult

--- a/MediaGallery/Permission/SaveMediaPermission.android.cs
+++ b/MediaGallery/Permission/SaveMediaPermission.android.cs
@@ -1,6 +1,6 @@
 ﻿using Android;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public partial class SaveMediaPermission
     {

--- a/MediaGallery/Permission/SaveMediaPermission.ios.cs
+++ b/MediaGallery/Permission/SaveMediaPermission.ios.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Photos;
 using Xamarin.Essentials;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public partial class SaveMediaPermission
     {

--- a/MediaGallery/Permission/SaveMediaPermission.netstandard.cs
+++ b/MediaGallery/Permission/SaveMediaPermission.netstandard.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public partial class SaveMediaPermission
     {

--- a/MediaGallery/Permission/SaveMediaPermission.shared.cs
+++ b/MediaGallery/Permission/SaveMediaPermission.shared.cs
@@ -1,6 +1,6 @@
 ﻿using static Xamarin.Essentials.Permissions;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     /// <summary>Permission "NSPhotoLibraryAddUsageDescription" for iOS and "WRITE_EXTERNAL_STORAGE" for Android</summary>
     public sealed partial class SaveMediaPermission : BasePlatformPermission

--- a/MediaGallery/Platform/Platform.android.cs
+++ b/MediaGallery/Platform/Platform.android.cs
@@ -3,7 +3,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     /// <summary>Platform specific helpers.</summary>
     public static partial class Platform

--- a/MediaGallery/Platform/Platform.ios.cs
+++ b/MediaGallery/Platform/Platform.ios.cs
@@ -1,6 +1,6 @@
 ﻿using UIKit;
 
-namespace Xamarin.MediaGallery
+namespace NativeMedia
 {
     public static partial class Platform
     {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ protected override void OnCreate(Bundle savedInstanceState)
 {
     //...
     base.OnCreate(savedInstanceState);
-    Xamarin.MediaGallery.Platform.Init(this, savedInstanceState);
+    NativeMedia.Platform.Init(this, savedInstanceState);
     //...
 }
  ```
@@ -38,8 +38,8 @@ protected override void OnCreate(Bundle savedInstanceState)
  ```csharp
 protected override void OnActivityResult(int requestCode, Result resultCode, Intent intent)
 {
-    if (Xamarin.MediaGallery.Platform.CheckCanProcessResult(requestCode, resultCode, intent))
-    Xamarin.MediaGallery.Platform.OnActivityResult(requestCode, resultCode, intent);
+    if (NativeMedia.Platform.CheckCanProcessResult(requestCode, resultCode, intent))
+    NativeMedia.Platform.OnActivityResult(requestCode, resultCode, intent);
     
     base.OnActivityResult(requestCode, resultCode, intent);
 }
@@ -77,13 +77,14 @@ var results = await MediaGallery.PickAsync(1, MediaFileType.Image, MediaFileType
 if (results?.Files == null)
     return;
 
-foreach(var res in results.Files)
+foreach(var file in results.Files)
 {
     var fileName = file.NameWithoutExtension; //Can return an null or empty value
     var extension = file.Extension;
     var contentType = file.ContentType;
     using var stream = await file.OpenReadAsync();
 //...
+    file.Dispose();
 }
  ```
 

--- a/Sample/Sample.Android/MainActivity.cs
+++ b/Sample/Sample.Android/MainActivity.cs
@@ -15,7 +15,7 @@ namespace Sample.Droid
             ToolbarResource = Resource.Layout.Toolbar;
 
             base.OnCreate(savedInstanceState);
-            Xamarin.MediaGallery.Platform.Init(this, savedInstanceState);
+            NativeMedia.Platform.Init(this, savedInstanceState);
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
             LoadApplication(new App());
@@ -30,8 +30,8 @@ namespace Sample.Droid
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent intent)
         {
-            if (Xamarin.MediaGallery.Platform.CheckCanProcessResult(requestCode, resultCode, intent))
-                Xamarin.MediaGallery.Platform.OnActivityResult(requestCode, resultCode, intent);
+            if (NativeMedia.Platform.CheckCanProcessResult(requestCode, resultCode, intent))
+                NativeMedia.Platform.OnActivityResult(requestCode, resultCode, intent);
 
             base.OnActivityResult(requestCode, resultCode, intent);
         }

--- a/Sample/Sample/Helpers/PermissionHelper.cs
+++ b/Sample/Sample/Helpers/PermissionHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Xamarin.Essentials;
-using Xamarin.MediaGallery;
 using static Xamarin.Essentials.Permissions;
 
 namespace Sample.Helpers

--- a/Sample/Sample/ViewModels/MediaFileInfoVM.cs
+++ b/Sample/Sample/ViewModels/MediaFileInfoVM.cs
@@ -3,8 +3,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using MetadataExtractor;
+using NativeMedia;
 using Sample.Helpers;
-using Xamarin.MediaGallery;
 
 namespace Sample.ViewModels
 {

--- a/Sample/Sample/ViewModels/PickVM.cs
+++ b/Sample/Sample/ViewModels/PickVM.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using NativeMedia;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
-using Xamarin.MediaGallery;
 
 namespace Sample.ViewModels
 {

--- a/Sample/Sample/ViewModels/SaveVM.cs
+++ b/Sample/Sample/ViewModels/SaveVM.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Input;
+using NativeMedia;
 using Sample.Helpers;
 using Xamarin.Essentials;
 using Xamarin.Forms;
-using Xamarin.MediaGallery;
 
 namespace Sample.ViewModels
 {

--- a/Sample/Sample/Views/MediaFileView.cs
+++ b/Sample/Sample/Views/MediaFileView.cs
@@ -1,6 +1,6 @@
-﻿using Xamarin.CommunityToolkit.UI.Views;
+﻿using NativeMedia;
+using Xamarin.CommunityToolkit.UI.Views;
 using Xamarin.Forms;
-using Xamarin.MediaGallery;
 
 namespace Sample.Views
 {

--- a/Sample/Sample/Views/PickPage.xaml
+++ b/Sample/Sample/Views/PickPage.xaml
@@ -4,7 +4,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:vm="clr-namespace:Sample.ViewModels"
-    xmlns:mediagallery="clr-namespace:Xamarin.MediaGallery;assembly=Xamarin.MediaGallery"
+    xmlns:media="clr-namespace:NativeMedia;assembly=NativeMedia"
     x:Class="Sample.Views.PickPage"
     x:DataType="vm:PickVM"
     Title="Pick"
@@ -25,7 +25,7 @@
                          BindableLayout.ItemsSource="{Binding SelectedItems}">
 
                 <BindableLayout.ItemTemplate>
-                    <DataTemplate x:DataType="mediagallery:IMediaFile">
+                    <DataTemplate x:DataType="media:IMediaFile">
                         <ContentView Padding="0,8">
                             <Label TextColor="DarkBlue" FontAttributes="Bold">
                                 <Label.Text>


### PR DESCRIPTION
### Description

I had to change the current namespace (`Xamarin.MediaGallery`):

- The old namespace echoed the name of the `MediaGallery` class
- If this is not an official package from Xamarin, then I think it is incorrect to call namespace starting with the word Xamarin
- I hope that I can transfer this package to `Microsoft.Maui.Essentials`, but if this does not out then the old namespace will not be very suitable in the future

### API Changes
namespace changed from `Xamarin.MediaGallery` to `NativeMedia`

### PR Checklist ###

- [x] All projects build
- [x] Rebased onto current `main`