### PR TITLE
PresentationSourceBounds improvements for .Net6 

### DIFF
--- a/MediaGallery/MediaGallery/PickMedia.ios.cs
+++ b/MediaGallery/MediaGallery/PickMedia.ios.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -78,16 +77,16 @@ namespace NativeMedia
 
                     if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
                     {
+                        var rect = request.PresentationSourceBounds.ToRect();
                         pickerRef.ModalPresentationStyle
-                            = request.PresentationSourceBounds != UsingsHelper.EmptyRectangle
+                            = rect != UsingsHelper.EmptyRectangle
                             ? UIModalPresentationStyle.Popover
                             : UIModalPresentationStyle.PageSheet;
 
                         if (pickerRef.PopoverPresentationController != null)
                         {
                             pickerRef.PopoverPresentationController.SourceView = vc.View;
-                            pickerRef.PopoverPresentationController.SourceRect
-                            = request.PresentationSourceBounds.AsCGRect();
+                            pickerRef.PopoverPresentationController.SourceRect = rect.AsCGRect();
                         }
                     }
 

--- a/MediaGallery/MediaGallery/PickMedia.ios.cs
+++ b/MediaGallery/MediaGallery/PickMedia.ios.cs
@@ -78,8 +78,7 @@ namespace NativeMedia
                     if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
                     {
                         var rect = request.PresentationSourceBounds.ToRect();
-                        pickerRef.ModalPresentationStyle
-                            = rect != UsingsHelper.EmptyRectangle
+                        pickerRef.ModalPresentationStyle = rect != UsingsHelper.EmptyRectangle
                             ? UIModalPresentationStyle.Popover
                             : UIModalPresentationStyle.PageSheet;
 

--- a/MediaGallery/MediaPickRequest/MediaPickRequest.shared.cs
+++ b/MediaGallery/MediaPickRequest/MediaPickRequest.shared.cs
@@ -25,8 +25,10 @@ namespace NativeMedia
         /// <summary>Media file types available for picking.</summary>
         public string Title { get; set; }
 
-        /// <summary>Gets or sets the source rectangle to display the Share UI from. This is only used on iPad currently.</summary>
-        public Rectangle PresentationSourceBounds { get; set; } = default;
+        /// <summary>Gets or sets the source rectangle to display the Picker UI from. This is only used on iPad currently.</summary>
+        /// <remarks>Xamarin - System.Drawing.Rectangle; &nbsp;
+        /// .net6(MAUI) - Microsoft.Maui.Graphics.Rectangle;</remarks>
+        public object PresentationSourceBounds { get; set; } = default;
 
         /// <summary>Gets or sets whether to use Intent.CreateChooser. Currently used only for Android.</summary>
         public bool UseCreateChooser { get; set; } = true;

--- a/MediaGallery/Usings/UsingsHelper.ios.cs
+++ b/MediaGallery/Usings/UsingsHelper.ios.cs
@@ -1,19 +1,1 @@
-﻿using CoreGraphics;
-
-static class UsingsHelper
-{
-    public static Rectangle EmptyRectangle =>
-#if NET6_0_IOS
-        Rectangle.Zero;
-#else
-        Rectangle.Empty;
-#endif
-
-    public static CGRect AsCGRect(this Rectangle rect) =>
-#if NET6_0_IOS
-        rect.AsCGRect();
-#else
-        rect.ToPlatformRectangle();
-#endif
-
-}
+﻿using CoreGraphics;static class UsingsHelper{    public static Rectangle EmptyRectangle =>#if NET6_0_IOS        Rectangle.Zero;#else        Rectangle.Empty;#endif    public static CGRect AsCGRect(this Rectangle rect) =>#if NET6_0_IOS        rect.AsCGRect();#else        rect.ToPlatformRectangle();#endif    public static Rectangle ToRect(this object val) =>        val is Rectangle rect ? rect : EmptyRectangle;}

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ protected override void OnActivityResult(int requestCode, Result resultCode, Int
 
 When picking files on iPadOS you have the ability to present in a pop over control. This specifies where the pop over will appear and point an arrow directly to. You can specify the location using the `PresentationSourceBounds` property. Setting this property has the same behavior as [Launcher or Share in Xamarin.Essentials](https://docs.microsoft.com/en-us/xamarin/essentials/share?tabs=android#presentation-location).
 
-`PresentationSourceBounds` property takes `System.Drawing.Rectangle` for `Xaamrin` or `Microsoft.Maui.Graphics.Rectangle` for `.net6(MAUI)`
+`PresentationSourceBounds` property takes `System.Drawing.Rectangle` for `Xamarin` or `Microsoft.Maui.Graphics.Rectangle` for `.net6(MAUI)`
 
 **Screenshots:**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![NuGet Badge](https://img.shields.io/nuget/vpre/Xamarin.MediaGallery)](https://www.nuget.org/packages/Xamarin.MediaGallery/) [![NuGet downloads](https://img.shields.io/nuget/dt/Xamarin.MediaGallery)](https://www.nuget.org/packages/Xamarin.MediaGallery/) [![license](https://img.shields.io/github/license/dimonovdd/Xamarin.MediaGallery)](https://github.com/dimonovdd/Xamarin.MediaGallery/blob/main/LICENSE) [![Xamarin.MediaGallery on fuget.org](https://www.fuget.org/packages/Xamarin.MediaGallery/badge.svg)](https://www.fuget.org/packages/Xamarin.MediaGallery) [![YouTube Video Views](https://img.shields.io/youtube/views/8JvgnlHVyrI?style=social)](https://youtu.be/8JvgnlHVyrI)
 
-
 This plugin is designed for picking and saving photos and video files from the native gallery of Android and iOS devices.
 
 *Unfortunately, at the time of the release of this plugin, [MediaPlugin](https://github.com/jamesmontemagno/MediaPlugin) by [@jamesmontemagno](https://github.com/jamesmontemagno) is no longer supported, and [Xamarin.Essentials](https://github.com/xamarin/Essentials) has not received updates for about 2 months.*
@@ -151,10 +150,12 @@ protected override void OnActivityResult(int requestCode, Result resultCode, Int
 
 When picking files on iPadOS you have the ability to present in a pop over control. This specifies where the pop over will appear and point an arrow directly to. You can specify the location using the `PresentationSourceBounds` property. Setting this property has the same behavior as [Launcher or Share in Xamarin.Essentials](https://docs.microsoft.com/en-us/xamarin/essentials/share?tabs=android#presentation-location).
 
+`PresentationSourceBounds` property takes `System.Drawing.Rectangle` for `Xaamrin` or `Microsoft.Maui.Graphics.Rectangle` for `.net6(MAUI)`
+
 **Screenshots:**
+
 - [Popover](https://raw.githubusercontent.com/dimonovdd/Xamarin.MediaGallery/main/Screenshots/iPadPopover.png)
 - [PageSheet](https://raw.githubusercontent.com/dimonovdd/Xamarin.MediaGallery/main/Screenshots/iPadPageSheet.png)
-
 
 # SaveAsync
 


### PR DESCRIPTION
### Related to issue
Closes: #65 

### API Changes
`PresentationSourceBounds` type has been changed to `object`. It takes `System.Drawing.Rectangle` for `Xamarin` or `Microsoft.Maui.Graphics.Rectangle` for `.net6(MAUI)`

```csharp
public object PresentationSourceBounds { get; set; }
```
### PR Checklist ###

- [x] All projects build
- [x] Has samples
- [x] Rebased onto current `main`