### PR TITLE
Capture photo with Metadata

### DIFF
--- a/MediaGallery/MediaFile/MediaFile.android.cs
+++ b/MediaGallery/MediaFile/MediaFile.android.cs
@@ -8,9 +8,11 @@ namespace NativeMedia
     partial class MediaFile
     {
         readonly Uri uri;
+        readonly string tempFilePath;
 
-        internal MediaFile(string fileName, Uri uri)
+        internal MediaFile(string fileName, Uri uri, string tempFilePath = null)
         {
+            this.tempFilePath = tempFilePath;
             NameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
             Extension = Path.GetExtension(fileName);
             ContentType = MimeTypeMap.Singleton.GetMimeTypeFromExtension(Extension);
@@ -21,6 +23,12 @@ namespace NativeMedia
         Task<Stream> PlatformOpenReadAsync()
             => Task.FromResult(Platform.AppActivity.ContentResolver.OpenInputStream(uri));
 
-        void PlatformDispose() { }
+        void PlatformDispose()
+        {
+            if(!string.IsNullOrWhiteSpace(tempFilePath) && File.Exists(tempFilePath))
+                File.Delete(tempFilePath);
+
+            uri?.Dispose();
+        }
     }
 }

--- a/MediaGallery/MediaFile/MediaFile.android.cs
+++ b/MediaGallery/MediaFile/MediaFile.android.cs
@@ -15,6 +15,7 @@ namespace NativeMedia
             Extension = Path.GetExtension(fileName);
             ContentType = MimeTypeMap.Singleton.GetMimeTypeFromExtension(Extension);
             this.uri = uri;
+            Type = GetFileType(ContentType);
         }
 
         Task<Stream> PlatformOpenReadAsync()

--- a/MediaGallery/MediaFile/MediaFile.ios.cs
+++ b/MediaGallery/MediaFile/MediaFile.ios.cs
@@ -56,7 +56,7 @@ namespace NativeMedia
 
         private string GetIdentifier(string[] identifiers)
         {
-            if (!(identifiers?.Any() ?? false))
+            if (!(identifiers?.Length > 0))
                 return null;
             if (identifiers.Any(i => i.StartsWith(UTType.LivePhoto)) && identifiers.Contains(UTType.JPEG))
                 return identifiers.FirstOrDefault(i => i == UTType.JPEG);
@@ -102,10 +102,11 @@ namespace NativeMedia
         NSDictionary metadata;
         NSMutableData imgWithMetadata;
 
-        internal PhotoFile(UIImage img, NSDictionary metadata)
+        internal PhotoFile(UIImage img, NSDictionary metadata, string name)
         {
             this.img = img;
             this.metadata = metadata;
+            NameWithoutExtension = name;
             ContentType = GetMIMEType(UTType.JPEG);
             Extension = GetExtension(UTType.JPEG);
             Type = GetFileType(ContentType);

--- a/MediaGallery/MediaFile/MediaFile.ios.cs
+++ b/MediaGallery/MediaFile/MediaFile.ios.cs
@@ -1,7 +1,10 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using CoreGraphics;
+using CoreImage;
 using Foundation;
+using ImageIO;
 using MobileCoreServices;
 using UIKit;
 
@@ -30,17 +33,15 @@ namespace NativeMedia
         {
             this.provider = provider;
             NameWithoutExtension = provider?.SuggestedName;
-            var identifiers = provider?.RegisteredTypeIdentifiers;
 
-            identifier = (identifiers?.Any(i => i.StartsWith(UTType.LivePhoto)) ?? false) && (identifiers?.Contains(UTType.JPEG) ?? false)
-                ? identifiers?.FirstOrDefault(i => i == UTType.JPEG)
-                : identifiers?.FirstOrDefault();
+            identifier = GetIdentifier(provider?.RegisteredTypeIdentifiers);
 
             if (string.IsNullOrWhiteSpace(identifier))
                 return;
 
             Extension = GetExtension(identifier);
             ContentType = GetMIMEType(identifier);
+            Type = GetFileType(ContentType);
         }
 
         protected override async Task<Stream> PlatformOpenReadAsync()
@@ -52,20 +53,34 @@ namespace NativeMedia
             provider = null;
             base.PlatformDispose();
         }
+
+        private string GetIdentifier(string[] identifiers)
+        {
+            if (!(identifiers?.Any() ?? false))
+                return null;
+            if (identifiers.Any(i => i.StartsWith(UTType.LivePhoto)) && identifiers.Contains(UTType.JPEG))
+                return identifiers.FirstOrDefault(i => i == UTType.JPEG);
+            if (identifiers.Contains(UTType.QuickTimeMovie))
+                return identifiers.FirstOrDefault(i => i == UTType.QuickTimeMovie);
+            return identifiers.FirstOrDefault();
+        }
     }
 
     class UIDocumentFile : MediaFile
     {
         UIDocument document;
+        NSUrl assetUrl;
 
         internal UIDocumentFile(NSUrl assetUrl, string fileName)
         {
+            this.assetUrl = assetUrl;
             document = new UIDocument(assetUrl);
             Extension = document.FileUrl.PathExtension;
             ContentType = GetMIMEType(document.FileType);
             NameWithoutExtension = !string.IsNullOrWhiteSpace(fileName)
                 ? Path.GetFileNameWithoutExtension(fileName)
                 : null;
+            Type = GetFileType(ContentType);
         }
 
         protected override Task<Stream> PlatformOpenReadAsync()
@@ -75,7 +90,61 @@ namespace NativeMedia
         {
             document?.Dispose();
             document = null;
+            assetUrl?.Dispose();
+            assetUrl = null;
             base.PlatformDispose();
+        }
+    }
+
+    class PhotoFile : MediaFile
+    {
+        UIImage img;
+        NSDictionary metadata;
+        NSMutableData imgWithMetadata;
+
+        internal PhotoFile(UIImage img, NSDictionary metadata)
+        {
+            this.img = img;
+            this.metadata = metadata;
+            ContentType = GetMIMEType(UTType.JPEG);
+            Extension = GetExtension(UTType.JPEG);
+            Type = GetFileType(ContentType);
+        }
+
+        protected override Task<Stream> PlatformOpenReadAsync()
+        {
+            imgWithMetadata ??= GetImageWithMeta();
+            return Task.FromResult(imgWithMetadata?.AsStream());
+        }
+
+        public NSMutableData GetImageWithMeta()
+        {
+            if (img == null || metadata == null)
+                return null;
+
+            using var source = CGImageSource.FromData(img.AsJPEG());
+            var destData = new NSMutableData();
+            using var destination = CGImageDestination.Create(destData, source.TypeIdentifier, 1, null);
+            destination.AddImage(source, 0, metadata);
+            destination.Close();
+            DisposeSources();
+            return destData;
+        }
+
+        protected override void PlatformDispose()
+        {
+            imgWithMetadata?.Dispose();
+            imgWithMetadata = null;
+            DisposeSources();
+            base.PlatformDispose();
+        }
+
+        void DisposeSources()
+        {
+            img?.Dispose();
+            img = null;
+            metadata?.Dispose();
+            metadata = null;
         }
     }
 }

--- a/MediaGallery/MediaFile/MediaFile.shared.cs
+++ b/MediaGallery/MediaFile/MediaFile.shared.cs
@@ -18,16 +18,24 @@ namespace NativeMedia
 
         public string ContentType { get; protected internal set; }
 
-        public MediaFileType? Type => ContentType.StartsWith("image")
-                ? MediaFileType.Image
-                : ContentType.StartsWith("video")
-                    ? MediaFileType.Video
-                    : (MediaFileType?)null;
+        public MediaFileType? Type { get; protected set; }
 
         public Task<Stream> OpenReadAsync()
             => PlatformOpenReadAsync();
 
         public void Dispose()
             => PlatformDispose();
+
+        protected MediaFileType? GetFileType(string contentType)
+        {
+            if (string.IsNullOrWhiteSpace(contentType))
+                return null;
+            if (ContentType.StartsWith("image"))
+                return MediaFileType.Image;
+            if (ContentType.StartsWith("video"))
+                return MediaFileType.Video;
+
+            return null;
+        }
     }
 }

--- a/MediaGallery/MediaGallery.csproj
+++ b/MediaGallery/MediaGallery.csproj
@@ -6,7 +6,7 @@
     <PackageId>Xamarin.MediaGallery</PackageId>
     <PackageTags>maui, xamarin, .net6, ios, android, toolkit, xamarin.forms, media, picker, photos, videos, mediapicker</PackageTags>
     <Description>This plugin is designed for picking and saving photos and video files from the native gallery of Android and iOS devices</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0-preview1</Version>
     <Authors>dimonovdd</Authors>
     <Owners>dimonovdd</Owners>
     <RepositoryUrl>https://github.com/dimonovdd/Xamarin.MediaGallery</RepositoryUrl>

--- a/MediaGallery/MediaGallery/MediaGallery.netstandard.cs
+++ b/MediaGallery/MediaGallery/MediaGallery.netstandard.cs
@@ -18,5 +18,11 @@ namespace NativeMedia
 
         static Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName)
             => Task.CompletedTask;
+
+        static bool PlatformCheckCapturePhotoSupport()
+            => false;
+
+        static Task<IMediaFile> PlatformCapturePhotoAsync(CancellationToken token)
+            => Task.FromResult<IMediaFile>(null);
     }
 }

--- a/MediaGallery/MediaGallery/MediaGallery.shared.cs
+++ b/MediaGallery/MediaGallery/MediaGallery.shared.cs
@@ -63,6 +63,12 @@ namespace NativeMedia
             await PlatformSaveAsync(type, filePath).ConfigureAwait(false);
         }
 
+        public static bool CheckCapturePhotoSupport()
+            => PlatformCheckCapturePhotoSupport();
+
+        public static Task<IMediaFile> CapturePhotoAsync(CancellationToken token = default)
+            => PlatformCapturePhotoAsync(token);
+
         static void CheckFileName(string fileName)
         {
             if (string.IsNullOrWhiteSpace(fileName))

--- a/MediaGallery/MediaGallery/PickMedia.android.cs
+++ b/MediaGallery/MediaGallery/PickMedia.android.cs
@@ -102,6 +102,12 @@ namespace NativeMedia
             }
         }
 
+        static bool PlatformCheckCapturePhotoSupport()
+             => false;
+
+        static Task<IMediaFile> PlatformCapturePhotoAsync(CancellationToken token)
+            => Task.FromResult<IMediaFile>(null);
+
         internal static void OnActivityResult(int requestCode, Result resultCode, Intent intent)
         {
             if (CheckCanProcessResult(requestCode, resultCode, intent))

--- a/MediaGallery/MediaGallery/PickMedia.ios.cs
+++ b/MediaGallery/MediaGallery/PickMedia.ios.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CoreGraphics;
 using Foundation;
 using MobileCoreServices;
 using Photos;
@@ -14,6 +15,7 @@ namespace NativeMedia
     public static partial class MediaGallery
     {
         static UIViewController pickerRef;
+        static UIViewController cameraRef;
 
         static async Task<IEnumerable<IMediaFile>> PlatformPickAsync(MediaPickRequest request, CancellationToken token)
         {
@@ -26,11 +28,11 @@ namespace NativeMedia
 
                 var tcs = new TaskCompletionSource<IEnumerable<IMediaFile>>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                CancelTaskIfRequested();
+                CancelTaskIfRequested(token, tcs);
 
                 await MainThread.InvokeOnMainThreadAsync(() =>
                 {
-                    CancelTaskIfRequested();
+                    CancelTaskIfRequested(token, tcs);
 
                     if (Platform.HasOSVersion(14))
                     {
@@ -72,7 +74,7 @@ namespace NativeMedia
                         };
                     }
 
-                    CancelTaskIfRequested();
+                    CancelTaskIfRequested(token, tcs);
                     var vc = Platform.GetCurrentUIViewController();
 
                     if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
@@ -89,41 +91,85 @@ namespace NativeMedia
                         }
                     }
 
-                    if (pickerRef.PresentationController != null)
-                        pickerRef.PresentationController.Delegate = new PresentatControllerDelegate(tcs);
+                    ConfigureController(pickerRef, tcs);
 
-                    CancelTaskIfRequested();
+                    CancelTaskIfRequested(token, tcs);
 
-                    vc.PresentViewController(pickerRef, true, () =>
-                    {
-                        if (!token.CanBeCanceled)
-                            return;
-
-                        token.Register(()
-                            => MainThread.BeginInvokeOnMainThread(()
-                                => pickerRef?.DismissViewController(true, ()
-                                    => tcs?.TrySetCanceled(token))));
-                    });
+                    vc.PresentViewController(pickerRef, true, () => PresentViewControllerHandler(pickerRef, token, tcs));
                 });
 
-                CancelTaskIfRequested(false);
+                CancelTaskIfRequested(token, tcs, false);
                 return await tcs.Task.ConfigureAwait(false);
-
-                void CancelTaskIfRequested(bool needThrow = true)
-                {
-                    if (token.IsCancellationRequested)
-                    {
-                        tcs?.TrySetCanceled(token);
-                        if (needThrow)
-                            token.ThrowIfCancellationRequested();
-                    }
-                }
             }
             finally
             {
                 pickerRef?.Dispose();
                 pickerRef = null;
             }
+        }
+
+        static bool PlatformCheckCapturePhotoSupport()
+            => UIImagePickerController.IsSourceTypeAvailable(UIImagePickerControllerSourceType.Camera);
+
+        static async Task<IMediaFile> PlatformCapturePhotoAsync(CancellationToken token)
+        {
+            if (!CheckCapturePhotoSupport())
+                throw new FeatureNotSupportedException();
+
+            var tcs = new TaskCompletionSource<IEnumerable<IMediaFile>>(TaskCreationOptions.RunContinuationsAsynchronously);
+            CancelTaskIfRequested(token, tcs, false);
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                CancelTaskIfRequested(token, tcs, false);
+
+                cameraRef = new UIImagePickerController
+                {
+                    SourceType = UIImagePickerControllerSourceType.Camera,
+                    AllowsEditing = false,
+                    AllowsImageEditing = false,
+                    Delegate = new PhotoPickerDelegate(tcs),
+                    CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Photo
+                };
+
+                CancelTaskIfRequested(token, tcs, false);
+                var vc = Platform.GetCurrentUIViewController();
+
+                ConfigureController(cameraRef, tcs);
+
+
+                CancelTaskIfRequested(token, tcs, false);
+                vc.PresentViewController(cameraRef, true, () => PresentViewControllerHandler(cameraRef, token, tcs));
+            });
+
+            var res = await tcs.Task.ConfigureAwait(false);
+            return res?.FirstOrDefault();
+        }
+
+        static void ConfigureController(UIViewController controller, TaskCompletionSource<IEnumerable<IMediaFile>> tcs)
+        {
+            if (controller.PresentationController != null)
+                controller.PresentationController.Delegate = new PresentatControllerDelegate(tcs);
+        }
+
+        static void CancelTaskIfRequested(CancellationToken token, TaskCompletionSource<IEnumerable<IMediaFile>> tcs, bool needThrow = true)
+        {
+            if (!token.IsCancellationRequested)
+                return;
+            tcs?.TrySetCanceled(token);
+            if (needThrow)
+                token.ThrowIfCancellationRequested();
+        }
+
+        static void PresentViewControllerHandler(UIViewController controller, CancellationToken token, TaskCompletionSource<IEnumerable<IMediaFile>> tcs)
+        {
+            if (!token.CanBeCanceled)
+                return;
+
+            token.Register(
+                ()=> MainThread.BeginInvokeOnMainThread(
+                    ()=> controller?.DismissViewController(true,
+                        ()=> tcs?.TrySetCanceled(token))));
         }
 
         class PHPickerDelegate : PHPickerViewControllerDelegate
@@ -172,15 +218,22 @@ namespace NativeMedia
                 if (info == null)
                     return null;
 
-                using var assetUrl = (info.ValueForKey(UIImagePickerController.ImageUrl)
+                var assetUrl = (info.ValueForKey(UIImagePickerController.ImageUrl)
                     ?? info.ValueForKey(UIImagePickerController.MediaURL)) as NSUrl;
 
                 var path = assetUrl?.Path;
 
-                if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
-                    return null;
+                if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+                    return new UIDocumentFile(assetUrl, GetOriginalName(info));
 
-                return new UIDocumentFile(assetUrl, GetOriginalName(info));
+                assetUrl?.Dispose();
+                var img = info.ValueForKey(UIImagePickerController.OriginalImage) as UIImage;
+                var meta = info.ValueForKey(UIImagePickerController.MediaMetadata) as NSDictionary;
+
+                if (img != null && meta != null)
+                    return new PhotoFile(img, meta);
+
+                return null;
             }
 
             string GetOriginalName(NSDictionary info)

--- a/MediaGallery/MediaGallery/PickMedia.ios.cs
+++ b/MediaGallery/MediaGallery/PickMedia.ios.cs
@@ -113,9 +113,6 @@ namespace NativeMedia
 
         static async Task<IMediaFile> PlatformCapturePhotoAsync(CancellationToken token)
         {
-            if (!CheckCapturePhotoSupport())
-                throw new FeatureNotSupportedException();
-
             var tcs = new TaskCompletionSource<IEnumerable<IMediaFile>>(TaskCreationOptions.RunContinuationsAsynchronously);
             CancelTaskIfRequested(token, tcs, false);
 
@@ -188,7 +185,7 @@ namespace NativeMedia
             static IEnumerable<IMediaFile> ConvertPickerResults(PHPickerResult[] results)
                 => results
                 .Select(res => res.ItemProvider)
-                .Where(provider => provider != null)
+                .Where(provider => provider != null && provider.RegisteredTypeIdentifiers?.Length > 0)
                 .Select(provider => new PHPickerFile(provider))
                 .ToArray();
         }
@@ -231,7 +228,7 @@ namespace NativeMedia
                 var meta = info.ValueForKey(UIImagePickerController.MediaMetadata) as NSDictionary;
 
                 if (img != null && meta != null)
-                    return new PhotoFile(img, meta);
+                    return new PhotoFile(img, meta, GetNewImageName());
 
                 return null;
             }

--- a/MediaGallery/MediaGallery/SaveMedia.android.cs
+++ b/MediaGallery/MediaGallery/SaveMedia.android.cs
@@ -9,11 +9,6 @@ using File = Java.IO.File;
 using Path = System.IO.Path;
 using Stream = System.IO.Stream;
 using Uri = Android.Net.Uri;
-#if MONOANDROID11_0 || NET6_0_ANDROID
-using MediaColumns = Android.Provider.MediaStore.IMediaColumns;
-#else
-using MediaColumns = Android.Provider.MediaStore.MediaColumns;
-#endif
 
 namespace NativeMedia
 {
@@ -40,7 +35,7 @@ namespace NativeMedia
 
             var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
             var extension = Path.GetExtension(fileName).ToLower();
-            var newFileName = $"{fileNameWithoutExtension}_{dateTimeNow:yyyyMMdd_HHmmss}{extension}";
+            var newFileName = $"{GetNewImageName(dateTimeNow, fileNameWithoutExtension)}{extension}";
 
             using var values = new ContentValues();
 

--- a/MediaGallery/MediaGallery/SaveMedia.ios.cs
+++ b/MediaGallery/MediaGallery/SaveMedia.ios.cs
@@ -8,8 +8,6 @@ namespace NativeMedia
 {
     public static partial class MediaGallery
     {
-        static readonly string cacheDir = "XamarinMediaGalleryCacheDir";
-
         static async Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName)
         {
             string filePath = null;
@@ -80,23 +78,6 @@ namespace NativeMedia
             var exception = await tcs.Task;
             if (exception != null)
                 throw exception;
-        }
-
-        static void DeleteFile(string filePath)
-        {
-            if (!string.IsNullOrWhiteSpace(filePath) && File.Exists(filePath))
-                File.Delete(filePath);
-        }
-
-        static string GetFilePath(string fileName)
-        {
-            fileName = fileName.Trim();
-            var dirPath = Path.Combine(FileSystem.CacheDirectory, cacheDir);
-            var filePath = Path.Combine(dirPath, fileName);
-
-            if (!Directory.Exists(dirPath))
-                Directory.CreateDirectory(dirPath);
-            return filePath;
         }
     }
 }

--- a/MediaGallery/Platform/Platform.android.cs
+++ b/MediaGallery/Platform/Platform.android.cs
@@ -7,7 +7,8 @@ namespace NativeMedia
     /// <summary>Platform specific helpers.</summary>
     public static partial class Platform
     {
-        internal static int requestCode = 1111;
+        internal static int pickRequestCode = 1111;
+        internal static int cameraRequestCode = 1112;
 
         /// <summary>Initialize Xamarin.MediaGallery with Android's activity and bundle.</summary>
         /// <param name="activity">Activity to use for initialization.</param>
@@ -30,5 +31,12 @@ namespace NativeMedia
 
         internal static bool HasSdkVersion(int version)
             => (int)Build.VERSION.SdkInt >= version;
+
+        internal static bool IsIntentSupported(Intent intent)
+        {
+            using var activity = intent.ResolveActivity(AppActivity.PackageManager);
+            return activity != null;
+        }
+            
     }
 }

--- a/MediaGallery/Usings/GlobalUsings.shared.cs
+++ b/MediaGallery/Usings/GlobalUsings.shared.cs
@@ -9,3 +9,8 @@ global using Xamarin.Essentials;
 #if XAMARIN_IOS
 global using Rectangle = System.Drawing.Rectangle;
 #endif
+#if MONOANDROID11_0 || NET6_0_ANDROID
+global using MediaColumns = Android.Provider.MediaStore.IMediaColumns;
+#elif MONOANDROID10_0
+global using MediaColumns = Android.Provider.MediaStore.MediaColumns;
+#endif

--- a/Sample/Common/ViewModels/PickVM.cs
+++ b/Sample/Common/ViewModels/PickVM.cs
@@ -112,7 +112,7 @@ public class PickVM : BaseVM
 
             var file = await MediaGallery.CapturePhotoAsync(cts.Token);
 
-            SelectedItems = new IMediaFile[] { file };
+            SelectedItems = file != null ?  new IMediaFile[] { file } : null;
             SetInfo(SelectedItems);
         }
         catch (Exception ex)
@@ -129,7 +129,7 @@ public class PickVM : BaseVM
     {
         if (SelectedItems?.Any() ?? false)
             foreach (var item in SelectedItems)
-                item.Dispose();
+                item?.Dispose();
         SelectedItems = null;
     }
 

--- a/Sample/Common/ViewModels/PickVM.cs
+++ b/Sample/Common/ViewModels/PickVM.cs
@@ -18,6 +18,7 @@ public class PickVM : BaseVM
         PickAnyCommand = new Command(() => Pick(null));
         PickImageCommand = new Command<View>(view => Pick(view, MediaFileType.Image));
         PickVideoCommand = new Command<View>(view => Pick(view, MediaFileType.Video));
+        CapturePhotoCommand = new Command(async () => await СapturePhotoAsync());
         OpenInfoCommand = new Command<IMediaFile>(async file => await NavigateAsync(new MediaFileInfoVM(file)));
     }
 
@@ -44,6 +45,8 @@ public class PickVM : BaseVM
 
     public ICommand PickVideoCommand { get; }
 
+    public ICommand CapturePhotoCommand { get; }
+
     public ICommand OpenInfoCommand { get; }
 
 
@@ -54,10 +57,7 @@ public class PickVM : BaseVM
             CancellationTokenSource cts = null;
             try
             {
-                if (SelectedItems?.Any() ?? false)
-                    foreach (var item in SelectedItems)
-                        item.Dispose();
-                SelectedItems = null;
+                DisposeItems();
 
                 cts = new CancellationTokenSource(
                     TimeSpan.FromMilliseconds(DelayMilliseconds));
@@ -73,9 +73,7 @@ public class PickVM : BaseVM
 
                 SelectedItems = result?.Files;
 
-                OperationInfo = SelectedItems?.Any() ?? false
-                    ? "Successfully"
-                    : "Media files not selected";
+                SetInfo(SelectedItems);
             }
             catch (Exception ex)
             {
@@ -87,4 +85,56 @@ public class PickVM : BaseVM
             }
         });
     }
+
+    async Task СapturePhotoAsync()
+    {
+        CancellationTokenSource cts = null;
+        try
+        {
+            DisposeItems();
+            if (!MediaGallery.CheckCapturePhotoSupport())
+            {
+                OperationInfo = "Capture Photo Not Supported";
+                return;
+            }
+
+            var status = await PermissionHelper.CheckAndRequest<Permissions.Camera>(
+                    "The application needs permission to camera");
+
+            if (!status)
+            {
+                await DisplayAlertAsync("The application did not get the necessary permission to camera");
+                return;
+            }
+
+            cts = new CancellationTokenSource(
+                    TimeSpan.FromMilliseconds(DelayMilliseconds));
+
+            var file = await MediaGallery.CapturePhotoAsync(cts.Token);
+
+            SelectedItems = new IMediaFile[] { file };
+            SetInfo(SelectedItems);
+        }
+        catch (Exception ex)
+        {
+            OperationInfo = ex.Message;
+        }
+        finally
+        {
+            cts?.Dispose();
+        }
+    }
+
+    void DisposeItems()
+    {
+        if (SelectedItems?.Any() ?? false)
+            foreach (var item in SelectedItems)
+                item.Dispose();
+        SelectedItems = null;
+    }
+
+    void SetInfo(IEnumerable<IMediaFile> files)
+        => OperationInfo = files?.Any() ?? false
+                    ? "Successfully"
+                    : "Media files not selected";
 }

--- a/Sample/MAUI/Views/PickPage.xaml
+++ b/Sample/MAUI/Views/PickPage.xaml
@@ -28,6 +28,7 @@
                     CommandParameter="{Binding Source={RelativeSource Self}}"/>
             <Button Text="Video" Command="{Binding PickVideoCommand, Mode=OneTime}"
                     CommandParameter="{Binding Source={RelativeSource Self}}"/>
+            <Button Text="Photo" Command="{Binding CapturePhotoCommand, Mode=OneTime}"/>
 
             <Label Text="Information about the completion of the operation:"/>
             <Label Text="{Binding OperationInfo}" MaxLines="4"/>

--- a/Sample/Xamarin/Sample.Android/Properties/AssemblyInfo.cs
+++ b/Sample/Xamarin/Sample.Android/Properties/AssemblyInfo.cs
@@ -27,3 +27,5 @@ using Android.App;
 // Add some common permissions, these can be removed if not needed
 [assembly: UsesPermission(Android.Manifest.Permission.Internet)]
 [assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]
+[assembly: UsesPermission(Android.Manifest.Permission.Camera)]
+[assembly: UsesFeature("android.hardware.camera", Required = false)]

--- a/Sample/Xamarin/Sample.iOS/Info.plist
+++ b/Sample/Xamarin/Sample.iOS/Info.plist
@@ -38,5 +38,7 @@
 	<string>For adding mediafiles</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>For adding mediafiles</string>
+	<key>NSCameraUsageDescription</key>
+	<string>For Capture photo</string>
 </dict>
 </plist>

--- a/Sample/Xamarin/Sample/Views/PickPage.xaml
+++ b/Sample/Xamarin/Sample/Views/PickPage.xaml
@@ -28,6 +28,7 @@
                     CommandParameter="{Binding Source={RelativeSource Self}}"/>
             <Button Text="Video" Command="{Binding PickVideoCommand, Mode=OneTime}"
                     CommandParameter="{Binding Source={RelativeSource Self}}"/>
+            <Button Text="Photo" Command="{Binding CapturePhotoCommand, Mode=OneTime}"/>
 
             <Label Text="Information about the completion of the operation:"/>
             <Label Text="{Binding OperationInfo}" MaxLines="4"/>

--- a/Xamarim.MediaGallery.targets
+++ b/Xamarim.MediaGallery.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project>
 	<PropertyGroup>
-		<_UseNuget>true</_UseNuget>
+		<_UseNuget>false</_UseNuget>
 		<_UseNuget Condition="'$(Configuration)'=='Release'">true</_UseNuget>
 		<_LibVersion>2.0.0</_LibVersion>
 		<_IsSample Condition="'$(_IsSample)'!='false'">true</_IsSample>

--- a/Xamarim.MediaGallery.targets
+++ b/Xamarim.MediaGallery.targets
@@ -1,19 +1,20 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project>
 	<PropertyGroup>
-		<_UseNuget>false</_UseNuget>
+		<_UseNuget>true</_UseNuget>
 		<_UseNuget Condition="'$(Configuration)'=='Release'">true</_UseNuget>
-		<_LibVersion>2.0.0</_LibVersion>
+		<_LibVersion>2.1.0-preview1</_LibVersion>
+		<_PermissionLibVersion>2.0.0</_PermissionLibVersion>
 		<_IsSample Condition="'$(_IsSample)'!='false'">true</_IsSample>
 		<_NET6 Condition=" $(TargetFramework.StartsWith('net6')) ">true</_NET6>
 		<_IsMobele Condition=" $(TargetFramework.Contains('droid')) OR $(TargetFramework.ToLowerInvariant().Contains('ios')) ">true</_IsMobele>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(_NET6)'=='true' AND ('$(_IsSample)'=='true' OR '$(_IsMobele)'=='true') ">
-		<PackageReference Condition="'$(_UseNuget)'=='true'" Include="Xamarin.MediaGallery.Permision.Maui" Version="$(_LibVersion)" />
+		<PackageReference Condition="'$(_UseNuget)'=='true'" Include="Xamarin.MediaGallery.Permision.Maui" Version="$(_PermissionLibVersion)" />
 		<ProjectReference Condition="'$(_UseNuget)'!='true'" Include="$(MSBuildThisFileDirectory)\Permission\Maui\Permission.Maui.csproj" />
   	</ItemGroup>
 	<ItemGroup Condition=" '$(_NET6)'!='true' AND ('$(_IsSample)'=='true' OR '$(_IsMobele)'=='true') ">
-		<PackageReference Condition="'$(_UseNuget)'=='true'" Include="Xamarin.MediaGallery.Permision" Version="$(_LibVersion)" />
+		<PackageReference Condition="'$(_UseNuget)'=='true'" Include="Xamarin.MediaGallery.Permision" Version="$(_PermissionLibVersion)" />
 		<ProjectReference Condition="'$(_UseNuget)'!='true'" Include="$(MSBuildThisFileDirectory)\Permission\Xamarin\Permission.csproj" />
   	</ItemGroup>
 	<ItemGroup Condition=" '$(_IsSample)'=='true' ">


### PR DESCRIPTION
### Description
This Pull Request also fixes possible bugs related to video picking on iOS and #80 

### Related to issue
- Closes: #81
- Closes: #80 

### API Changes
**Added:**

```csharp
public static bool CheckCapturePhotoSupport();

public static Task<IMediaFile> CapturePhotoAsync(CancellationToken token = default);
```

### Recommendations for testing
Just capture photos

### PR Checklist ###

- [x] All projects build
- [x] Has samples
- [x] Rebased onto current `main`