### PR TITLE
Feature - custom albums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ packages/
 
 #Android Resource designer
 Resource.designer.cs
+
+#Ignore macOS .DS_Store files.
+.DS_Store

--- a/MediaGallery/MediaGallery.csproj
+++ b/MediaGallery/MediaGallery.csproj
@@ -7,7 +7,7 @@
     <PackageId>Xamarin.MediaGallery</PackageId>
     <PackageTags>maui, xamarin, .net6, ios, android, toolkit, xamarin.forms, media, picker, photos, videos, mediapicker</PackageTags>
     <Description>This plugin is designed for picking and saving photos and video files from the native gallery of Android and iOS devices</Description>
-    <Version>2.2.1</Version>
+    <Version>2.2.2-preview1</Version>
     <Authors>dimonovdd</Authors>
     <Owners>dimonovdd</Owners>
     <RepositoryUrl>https://github.com/dimonovdd/Xamarin.MediaGallery</RepositoryUrl>

--- a/MediaGallery/MediaGallery/MediaGallery.netstandard.cs
+++ b/MediaGallery/MediaGallery/MediaGallery.netstandard.cs
@@ -10,13 +10,13 @@ namespace NativeMedia
         static Task<IEnumerable<IMediaFile>> PlatformPickAsync(MediaPickRequest request, CancellationToken token)
             => Task.FromResult<IEnumerable<IMediaFile>>(null);
 
-        static Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName)
+        static Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName, string albumName = null)
              => Task.CompletedTask;
 
-        static Task PlatformSaveAsync(MediaFileType type, string filePath)
+        static Task PlatformSaveAsync(MediaFileType type, string filePath, string albumName = null)
             => Task.CompletedTask;
 
-        static Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName)
+        static Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName, string albumName = null)
             => Task.CompletedTask;
 
         static bool PlatformCheckCapturePhotoSupport()

--- a/MediaGallery/MediaGallery/MediaGallery.shared.cs
+++ b/MediaGallery/MediaGallery/MediaGallery.shared.cs
@@ -31,38 +31,40 @@ namespace NativeMedia
         /// <param name="type">Type of media file to save.</param>
         /// <param name="fileStream">The stream to output the file to.</param>
         /// <param name="fileName">The name of the saved file including the extension.</param>
+        /// <param name="albumName">The name of the album to save the file to. Null for default behaviour, empty string for no album, anything else to create/use an album.</param>
         /// <returns>A task representing the asynchronous save operation.</returns>
-        public static async Task SaveAsync(MediaFileType type, Stream fileStream, string fileName)
+        public static async Task SaveAsync(MediaFileType type, Stream fileStream, string fileName, string albumName = null)
         {
             await CheckPossibilitySave();
+
             if (fileStream == null)
                 throw new ArgumentNullException(nameof(fileStream));
             CheckFileName(fileName);
 
-           await PlatformSaveAsync(type, fileStream, fileName).ConfigureAwait(false);
+           await PlatformSaveAsync(type, fileStream, fileName, albumName).ConfigureAwait(false);
         }
 
         /// <param name="data">A byte array to save to the file.</param>
-        /// <inheritdoc cref = "SaveAsync(MediaFileType, Stream, string)" path=""/>
-        public static async Task SaveAsync(MediaFileType type, byte[] data, string fileName)
+        /// <inheritdoc cref = "SaveAsync(MediaFileType, Stream, string, string?)" path=""/>
+        public static async Task SaveAsync(MediaFileType type, byte[] data, string fileName, string albumName = null)
         {
             await CheckPossibilitySave();
             if (!(data?.Length > 0))
                 throw new ArgumentNullException(nameof(data));
             CheckFileName(fileName);
 
-            await PlatformSaveAsync(type, data, fileName).ConfigureAwait(false);
+            await PlatformSaveAsync(type, data, fileName, albumName).ConfigureAwait(false);
         }
 
         /// <param name="filePath">Full path to a local file.</param>
-        /// <inheritdoc cref = "SaveAsync(MediaFileType, Stream, string)" path=""/>
-        public static async Task SaveAsync(MediaFileType type, string filePath)
+        /// <inheritdoc cref = "SaveAsync(MediaFileType, Stream, string, string?)" path=""/>
+        public static async Task SaveAsync(MediaFileType type, string filePath, string albumName = null)
         {
             await CheckPossibilitySave();
             if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
                 throw new ArgumentException(nameof(filePath));
 
-            await PlatformSaveAsync(type, filePath).ConfigureAwait(false);
+            await PlatformSaveAsync(type, filePath, albumName).ConfigureAwait(false);
         }
 
         /// <summary>Checks camera support on a device</summary>

--- a/MediaGallery/MediaGallery/SaveMedia.android.cs
+++ b/MediaGallery/MediaGallery/SaveMedia.android.cs
@@ -14,21 +14,24 @@ namespace NativeMedia
 {
     public static partial class MediaGallery
     {
-        static async Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName)
+        static async Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName, string albumName = null)
         {
             using var ms = new MemoryStream(data);
-            await PlatformSaveAsync(type, ms, fileName).ConfigureAwait(false);
+            await PlatformSaveAsync(type, ms, fileName, albumName).ConfigureAwait(false);
         }
 
-        static async Task PlatformSaveAsync(MediaFileType type, string filePath)
+        static async Task PlatformSaveAsync(MediaFileType type, string filePath, string albumName = null)
         {
             using var fileStream = System.IO.File.OpenRead(filePath);
-            await PlatformSaveAsync(type, fileStream, Path.GetFileName(filePath)).ConfigureAwait(false);
+            await PlatformSaveAsync(type, fileStream, Path.GetFileName(filePath), albumName).ConfigureAwait(false);
         }
 
-        static async Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName)
+        static async Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName, string albumName = null)
         {
-            var albumName = AppInfo.Name;
+            if (albumName == null)
+            {
+                albumName = AppInfo.Name;
+            }
 
             var context = Platform.AppActivity;
             var dateTimeNow = DateTime.Now;

--- a/MediaGallery/MediaGallery/SaveMedia.ios.cs
+++ b/MediaGallery/MediaGallery/SaveMedia.ios.cs
@@ -53,14 +53,18 @@ namespace NativeMedia
             // If albumName is null we do what we always used to do and not create an album.
             // If albumName is an empty string we don't wish to create an album (which is the same as null for iOS)
             // Otherwise we wish to create an album.
-            if (String.IsNullOrEmpty(albumName) == false)
+            if (string.IsNullOrEmpty(albumName) == false)
             {
                 // Fetch album.
                 var fetchOptions = new PHFetchOptions()
                 {
                     Predicate = NSPredicate.FromFormat($"title=\"{albumName}\"")
                 };
+                #if __NET6__
+                collection = PHAssetCollection.FetchAssetCollections(PHAssetCollectionType.Album, PHAssetCollectionSubtype.AlbumRegular, fetchOptions).firstObject as PHAssetCollection;
+                #else
                 collection = PHAssetCollection.FetchAssetCollections(PHAssetCollectionType.Album, PHAssetCollectionSubtype.AlbumRegular, fetchOptions).FirstObject as PHAssetCollection;
+                #endif
 
                 // Album does not exist, create it.
                 if (collection == null)
@@ -99,7 +103,11 @@ namespace NativeMedia
                 if (success)
                 {
                     var collectionFetchResult = PHAssetCollection.FetchAssetCollections(new string[] { placeholderForCreatedAssetCollection.LocalIdentifier }, null);
+                    #if __NET6__
+                    var newCollection = collectionFetchResult.firstObject as PHAssetCollection;
+                    #else
                     var newCollection = collectionFetchResult.FirstObject as PHAssetCollection;
+                    #endif
                     tcs.TrySetResult(newCollection);
                 }
                 else

--- a/MediaGallery/MediaGallery/SaveMedia.ios.cs
+++ b/MediaGallery/MediaGallery/SaveMedia.ios.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using System.Xml;
 using Foundation;
 using Photos;
 
@@ -8,7 +9,7 @@ namespace NativeMedia
 {
     public static partial class MediaGallery
     {
-        static async Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName)
+        static async Task PlatformSaveAsync(MediaFileType type, byte[] data, string fileName, string albumName = null)
         {
             string filePath = null;
 
@@ -17,7 +18,7 @@ namespace NativeMedia
                 filePath = GetFilePath(fileName);
                 await File.WriteAllBytesAsync(filePath, data);
 
-                await PlatformSaveAsync(type, filePath).ConfigureAwait(false);
+                await PlatformSaveAsync(type, filePath, albumName).ConfigureAwait(false);
             }
             finally
             {
@@ -25,7 +26,7 @@ namespace NativeMedia
             }
         }
 
-        static async Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName)
+        static async Task PlatformSaveAsync(MediaFileType type, Stream fileStream, string fileName, string albumName = null)
         {
             string filePath = null;
 
@@ -36,7 +37,7 @@ namespace NativeMedia
                 await fileStream.CopyToAsync(stream);
                 stream.Close();
 
-                await PlatformSaveAsync(type, filePath).ConfigureAwait(false);
+                await PlatformSaveAsync(type, filePath, albumName).ConfigureAwait(false);
             }
             finally
             {
@@ -44,16 +45,70 @@ namespace NativeMedia
             }
         }
 
-        static async Task PlatformSaveAsync(MediaFileType type, string filePath)
+        static async Task PlatformSaveAsync(MediaFileType type, string filePath, string albumName = null)
         {
             using var fileUri = new NSUrl(filePath);
+            
+            PHAssetCollection collection = null;
+            // If albumName is null we do what we always used to do and not create an album.
+            // If albumName is an empty string we don't wish to create an album (which is the same as null for iOS)
+            // Otherwise we wish to create an album.
+            if (String.IsNullOrEmpty(albumName) == false)
+            {
+                // Fetch album.
+                var fetchOptions = new PHFetchOptions()
+                {
+                    Predicate = NSPredicate.FromFormat($"title=\"{albumName}\"")
+                };
+                collection = PHAssetCollection.FetchAssetCollections(PHAssetCollectionType.Album, PHAssetCollectionSubtype.AlbumRegular, fetchOptions).FirstObject as PHAssetCollection;
+
+                // Album does not exist, create it.
+                if (collection == null)
+                {
+                    collection = await PhotoLibraryCreateAlbum(albumName).ConfigureAwait(false);
+                }
+            }
 
             await PhotoLibraryPerformChanges(() =>
             {
                 using var request = type == MediaFileType.Video
                 ? PHAssetChangeRequest.FromVideo(fileUri)
                 : PHAssetChangeRequest.FromImage(fileUri);
+
+                // If we have a collection we should put the asset into it.
+                if (collection != null)
+                {
+                    var assetCollectionChangeRequest = PHAssetCollectionChangeRequest.ChangeRequest(collection);
+                    assetCollectionChangeRequest.AddAssets(new PHObject[] { request.PlaceholderForCreatedAsset });
+                }
+
             }).ConfigureAwait(false);
+        }
+
+        static async Task<PHAssetCollection> PhotoLibraryCreateAlbum(string albumName)
+        {
+            var tcs = new TaskCompletionSource<PHAssetCollection>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            PHObjectPlaceholder placeholderForCreatedAssetCollection = null;
+            PHPhotoLibrary.SharedPhotoLibrary.PerformChanges(() =>
+            {
+                var createAlbum = PHAssetCollectionChangeRequest.CreateAssetCollection(albumName);
+                placeholderForCreatedAssetCollection = createAlbum.PlaceholderForCreatedAssetCollection;
+            }, (bool success, NSError error) =>
+            {
+                if (success)
+                {
+                    var collectionFetchResult = PHAssetCollection.FetchAssetCollections(new string[] { placeholderForCreatedAssetCollection.LocalIdentifier }, null);
+                    var newCollection = collectionFetchResult.FirstObject as PHAssetCollection;
+                    tcs.TrySetResult(newCollection);
+                }
+                else
+                {
+                    tcs.TrySetResult(null);
+                }
+            });
+
+            return await tcs.Task;
         }
 
         static async Task PhotoLibraryPerformChanges(Action action)

--- a/Permission/Xamarim.MediaGallery.Permission.targets
+++ b/Permission/Xamarim.MediaGallery.Permission.targets
@@ -3,7 +3,7 @@
 	<PropertyGroup>
     <PackageTags>maui, xamarin, .net6, ios, android, toolkit, xamarin.forms, media, picker, photos, videos, mediapicker</PackageTags>
     <Description>This plugin is designed for picking and saving photos and video files from the native gallery of Android and iOS devices</Description>
-    <Version>2.2.1</Version>
+    <Version>2.2.2-preview1</Version>
     <Authors>dimonovdd</Authors>
     <Owners>dimonovdd</Owners>
     <RepositoryUrl>https://github.com/dimonovdd/Xamarin.MediaGallery</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ await MediaGallery.SaveAsync(MediaFileType.Video, filePath);
 
 await MediaGallery.SaveAsync(MediaFileType.Image, stream, fileName);
 
+//OR You can also save to a specific album
+
+await MediaGallery.SaveAsync(MediaFileType.Image, stream, fileName, "MyAppsAlbum");
+
 //The name or the path to the saved file must contain the extension.
 
 //...

--- a/Sample/Common/src/ViewModels/SaveVM.cs
+++ b/Sample/Common/src/ViewModels/SaveVM.cs
@@ -41,6 +41,8 @@ public class SaveVM : BaseVM
 
     public ICommand SaveVideoCommand { get; }
 
+    public string AlbumName { get; set; }
+
 
     async void Save(MediaFileType type, string name)
     {
@@ -57,22 +59,29 @@ public class SaveVM : BaseVM
         {
             using var stream = EmbeddedResourceProvider.Load(name);
 
+            // Note on the albumName parameter.
+            // If the albumName parameter is an empty string no album will be created but it will be just saved into photos/gallery.
+            // If the albumName parameter is a string then an album by that name will created and/or used.
+            // If the albumName parameter is null we use the behaviour from Xamarin.MediaGallery v2.2.1 (app name as album for Android, no album for iOS)
+            // In this sample we do not allow it to be null.
+            var albumName = AlbumName ?? String.Empty;
+
             if (FromStream)
             {
-                await MediaGallery.SaveAsync(type, stream, name);
+                await MediaGallery.SaveAsync(type, stream, name, albumName);
             }
             else if (FromByteArray)
             {
                 using var memoryStream = new MemoryStream();
                 stream.CopyTo(memoryStream);
 
-                await MediaGallery.SaveAsync(type, memoryStream.ToArray(), name);
+                await MediaGallery.SaveAsync(type, memoryStream.ToArray(), name, albumName);
             }
             else if (FromCacheDirectory)
             {
                 var filePath = await FilesHelper.SaveToCacheAsync(stream, name);
 
-                await MediaGallery.SaveAsync(type, filePath);
+                await MediaGallery.SaveAsync(type, filePath, albumName);
             }
 
             await DisplayAlertAsync("Save Completed Successfully");

--- a/Sample/MAUI/Views/SavePage.xaml
+++ b/Sample/MAUI/Views/SavePage.xaml
@@ -20,6 +20,10 @@
                 <RadioButton Content="Stream" IsChecked="{Binding FromStream}" />
                 <RadioButton Content="ByteArray" IsChecked="{Binding FromByteArray}" />
                 <RadioButton Content="CacheDirectory" IsChecked="{Binding FromCacheDirectory}" />
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Save to album:" VerticalOptions="Center" />
+                    <Entry Text="{Binding AlbumName}" Placeholder="Leave blank for no album" VerticalOptions="Center" />
+                </StackLayout>
             </StackLayout>
 
             <Grid Grid.Row="1" Margin="0" >

--- a/Sample/Xamarin/Sample/Views/SavePage.xaml
+++ b/Sample/Xamarin/Sample/Views/SavePage.xaml
@@ -20,6 +20,10 @@
                 <RadioButton Content="Stream" IsChecked="{Binding FromStream}" />
                 <RadioButton Content="ByteArray" IsChecked="{Binding FromByteArray}" />
                 <RadioButton Content="CacheDirectory" IsChecked="{Binding FromCacheDirectory}" />
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Save to album:" VerticalOptions="Center" />
+                    <Entry Text="{Binding AlbumName}" Placeholder="Leave blank for no album" VerticalOptions="Center" />
+                </StackLayout>
             </StackLayout>
 
             <Grid Grid.Row="1" Margin="0" >

--- a/Xamarim.MediaGallery.targets
+++ b/Xamarim.MediaGallery.targets
@@ -3,8 +3,8 @@
 	<PropertyGroup>
 		<_UseNuget>true</_UseNuget>
 		<_UseNuget Condition="'$(Configuration)'=='Release'">true</_UseNuget>
-		<_LibVersion>2.2.1</_LibVersion>
-		<_PermissionLibVersion>2.2.1</_PermissionLibVersion>
+		<_LibVersion>2.2.2-preview1</_LibVersion>
+		<_PermissionLibVersion>2.2.2-preview1</_PermissionLibVersion>
 		<_IsSample Condition="'$(_IsSample)'!='false'">true</_IsSample>
 		<_NET6 Condition=" $(TargetFramework.StartsWith('net6')) ">true</_NET6>
 		<_IsMobele Condition=" $(TargetFramework.Contains('droid')) OR $(TargetFramework.ToLowerInvariant().Contains('ios')) ">true</_IsMobele>


### PR DESCRIPTION
### Description
Adds the ability to create albums when saving assets. 

### Related to issue
Fixes #122 

### API Changes
No breaking changes.
`SaveAsync` now has an additional argument `albumName` which is null by default.
If `albumName` is null then we continue doing what we do (iOS: No album, Android: Album created of the same name as the app).
If `albumName` is an empty string then no album will be created on both iOS and Android.
If `albumName` is anything else, then an album is created with that name on both iOS and Android.

### Recommendations for testing
I didn't update the sample app as I wasn't sure how to express "keeping this blank will make an album on Android, no album on iOS". But the way I tested was  by changing things in `SaveVM.cs`, from:

```csharp
await MediaGallery.SaveAsync(type, stream, name);
```

to:
```csharp
await MediaGallery.SaveAsync(type, stream, name, "My Album");
```

### PR Checklist ###

- [x] All projects build
- [x] Has samples
- [x] Rebased onto current `main`