### PR TITLE
drop UseCreateChooser

### DIFF
--- a/MediaGallery/MediaPickRequest/MediaPickRequest.shared.cs
+++ b/MediaGallery/MediaPickRequest/MediaPickRequest.shared.cs
@@ -11,7 +11,7 @@ public class MediaPickRequest
         SelectionLimit = selectionLimit > 0 ? selectionLimit : 1;
         Types = types?.Length > 0
             ? types.Distinct().ToArray()
-            : new MediaFileType[] { MediaFileType.Image, MediaFileType.Video };
+            : [ MediaFileType.Image, MediaFileType.Video];
     }
 
     /// <summary>Maximum count of files to pick. On Android the option just sets multiple pick allowed.</summary>
@@ -24,8 +24,5 @@ public class MediaPickRequest
     public string Title { get; set; }
 
     /// <summary>Gets or sets the source rectangle to display the Picker UI from. This is only used on iPad currently.</summary>
-    public Rect? PresentationSourceBounds { get; set; } = default;
-
-    /// <summary>Gets or sets whether to use Intent.CreateChooser. Currently used only for Android.</summary>
-    public bool UseCreateChooser { get; set; } = true;
+    public Rect? PresentationSourceBounds { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ try
     var request = new MediaPickRequest(1, MediaFileType.Image, MediaFileType.Video)
     {
         PresentationSourceBounds = System.Drawing.Rectangle.Empty,
-        UseCreateChooser = true,
         Title = "Select"
     };
 
@@ -166,20 +165,17 @@ protected override void OnActivityResult(int requestCode, Result resultCode, Int
 - When using `PickAsync` method `selectionLimit` parameter just sets multiple pick allowed
 - A request to cancel `PickAsync` method will cancel a task, but the picker UI can remain open until it is closed by the user
 - The use of `Title` property depends on each device
-- `UseCreateChooser` property has not been used since version 2.0.0
 
 #### Photo Picker behavior
 
 - `selectionLimit` parameter limits the number of selected media files
 - `Title` property not used
-- `UseCreateChooser` property not used
 
 ### iOS
 
 - Multi picking is supported since iOS version 14.0+ On older versions, the plugin will prompt the user to select a single file
 - The `NameWithoutExtension` property on iOS versions before 14 returns a null value if the permission to access photos was not granted
 - `Title` property not used
-- `UseCreateChooser` property not used
 
 #### Presentation Location
 


### PR DESCRIPTION
### Description

### API Changes

`UseCreateChooser ` property has been deleted. It is not used after merging https://github.com/dimonovdd/Xamarin.MediaGallery/pull/82

```csharp
public class MediaPickRequest
{
    /// <summary>Gets or sets whether to use Intent.CreateChooser. Currently used only for Android.</summary>
    public bool UseCreateChooser { get; set; } = true;
}
```


https://github.com/dimonovdd/Xamarin.MediaGallery/pull/82

### PR Checklist ###

- [x] All projects build
- [x] Has samples
- [x] Rebased onto current `main`